### PR TITLE
feat: loading and error states

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Props = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function Error({ error, reset }: Props) {
+  useEffect(() => {
+    console.error(error); // could use something like datadog to log the error
+  }, [error]);
+
+  return (
+    <div className="container mx-auto px-4 min-h-screen flex flex-col items-center justify-center gap-4">
+      <h2 className="text-2xl font-bold text-red-600">Something went wrong!</h2>
+      <p className="text-gray-600">{error.message}</p>
+      <button
+        onClick={reset}
+        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+import LoadingEditions from "@/features/editions/components/LoadingEditions";
+
+export default function Loading() {
+  return (
+    <div className="container mx-auto px-4 min-h-screen flex items-center justify-center">
+      <LoadingEditions />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import EditionList from "@/features/editions/components/EditionList";
 import { getEditionsFromLocal } from "@/features/editions/api";
 
@@ -10,17 +9,15 @@ type Props = {
 };
 
 export default async function Home({ searchParams }: Props) {
-  const params = await searchParams; // we have to await the searchParams object as per the nextjs docs
-  const currentPage = parseInt(params.page || "1");
-  const limit = parseInt(params.limit || "10");
+  const params = await searchParams; // we have to await params as per nextjs docs: https://nextjs.org/docs/messages/sync-dynamic-apis
+  const currentPage = Math.max(1, parseInt(params.page || "1"));
+  const limit = Math.max(1, parseInt(params.limit || "10"));
 
   const editions = await getEditionsFromLocal(currentPage, limit);
 
   return (
     <div className="container mx-auto px-4">
-      <Suspense fallback={<div>Loading...</div>}>
-        <EditionList data={editions} currentPage={currentPage} />
-      </Suspense>
+      <EditionList data={editions} currentPage={currentPage} />
     </div>
   );
 }

--- a/src/features/editions/components/LoadingEditions.tsx
+++ b/src/features/editions/components/LoadingEditions.tsx
@@ -1,0 +1,18 @@
+const LoadingEditions = () => {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {[...Array(6)].map((_, i) => (
+        <div key={i} className="border p-4 rounded-lg animate-pulse">
+          <div className="h-6 bg-gray-200 rounded w-3/4 mb-4"></div>
+          <div className="space-y-3">
+            <div className="h-4 bg-gray-200 rounded"></div>
+            <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+            <div className="h-4 bg-gray-200 rounded w-4/6"></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LoadingEditions;


### PR DESCRIPTION
using nextjs error route to catch any network errors

using nextjs loading route to add loading state for network requests

because of the global loading screen and because we will
not have any api calls inside of the component this can be removed

also added validation for the search params

simple component with a skeleton similar to the layout of the
cards on the main page